### PR TITLE
Limit max connections and dht concurrency to half

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Add a new preference to limit active torrents to 1 (https://github.com/lewisl9029/webtorrent-desktop/pull/1)
 - Add a remove completed torrents button to header (https://github.com/lewisl9029/webtorrent-desktop/pull/2)
 
+### Changed
+- Halved default max connection limit and DHT concurrency (workaround for https://github.com/webtorrent/webtorrent-desktop/issues/932) (https://github.com/lewisl9029/webtorrent-desktop/pull/6)
+
 ## v0.18.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "gh-release": "gh-release",
     "open-config": "node ./bin/open-config.js",
     "package": "node ./bin/package.js",
+    "package-custom": "npm run package -- win32 --package=exe",
     "prepublish": "npm run build",
     "start": "npm run build && electron .",
     "test": "standard && depcheck --ignores=buble,nodemon,gh-release,standard --ignore-dirs=build,dist && node ./bin/extra-lint.js",

--- a/src/renderer/webtorrent.js
+++ b/src/renderer/webtorrent.js
@@ -62,7 +62,13 @@ const PEER_ID = Buffer.from(VERSION_PREFIX + crypto.randomBytes(9).toString('bas
 
 // Connect to the WebTorrent and BitTorrent networks. WebTorrent Desktop is a hybrid
 // client, as explained here: https://webtorrent.io/faq
-let client = window.client = new WebTorrent({ peerId: PEER_ID })
+let client = window.client = new WebTorrent({
+  peerId: PEER_ID,
+  maxConns: 25,
+  dht: {
+    concurrency: 8
+  }
+})
 
 // WebTorrent-to-HTTP streaming sever
 let server = null


### PR DESCRIPTION
As a workaround for https://github.com/webtorrent/webtorrent-desktop/issues/932

Seems to be working fine for me on a ~300 Mbps connection with 9 simultaneous torrents, and 25 connections on a single torrent seems to be enough to saturate my connection on popular torrents.

Haven't experienced any hangs since I started using this new build. Will follow up with some more fine grained tuning using a wired 1 Gbps connection.